### PR TITLE
chore: add ci yml

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,2 @@
+# What's Changed?
+

--- a/.github/workflows/ci-alpha.yml
+++ b/.github/workflows/ci-alpha.yml
@@ -1,0 +1,11 @@
+name: CI Alpha
+
+on:
+  push:
+    branches-ignore: [ master ]
+  pull_request:
+    branches-ignore: [ master ]
+
+jobs:
+  call-common:
+    uses: ./.github/workflows/ci-common.yml

--- a/.github/workflows/ci-alpha.yml
+++ b/.github/workflows/ci-alpha.yml
@@ -3,8 +3,6 @@ name: CI Alpha
 on:
   push:
     branches-ignore: [ master ]
-  pull_request:
-    branches-ignore: [ master ]
 
 jobs:
   call-common:

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -1,0 +1,37 @@
+name: CI Common
+
+on:
+  workflow_call:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Check formatting
+        run: pnpm format:check
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test 

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -14,7 +14,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
       - name: Install pnpm
         uses: pnpm/action-setup@v3

--- a/.github/workflows/ci-common.yml
+++ b/.github/workflows/ci-common.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v3
         with:
-          version: 8
+          version: 10.9.0
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,11 @@
+name: CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  call-common:
+    uses: ./.github/workflows/ci-common.yml

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,2 +1,3 @@
 pnpm-lock.yaml
 public
+.github

--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "postcss-prefixer": "^3.0.0",
     "postcss-scope": "^1.7.4",
     "postcss-transformselectors": "^2.0.1",
+    "prettier": "^3.6.0",
     "rimraf": "^6.0.1",
     "storybook": "8.4.7",
     "tailwindcss": "^3.4.11",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.0.135",
   "type": "module",
+  "engines": {
+    "node": ">=18",
+    "pnpm": ">=8"
+  },
   "scripts": {
     "pre-commit": "lint-staged",
     "predeploy": "npm version patch && npm run build:github",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -113,28 +113,28 @@ importers:
         version: 1.0.5
       '@storybook/addon-essentials':
         specifier: 8.4.7
-        version: 8.4.7(@types/react@18.3.23)(storybook@8.4.7(prettier@3.5.3))
+        version: 8.4.7(@types/react@18.3.23)(storybook@8.4.7(prettier@3.6.0))
       '@storybook/addon-interactions':
         specifier: 8.4.7
-        version: 8.4.7(storybook@8.4.7(prettier@3.5.3))
+        version: 8.4.7(storybook@8.4.7(prettier@3.6.0))
       '@storybook/addon-links':
         specifier: 8.4.7
-        version: 8.4.7(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))
+        version: 8.4.7(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))
       '@storybook/addon-onboarding':
         specifier: 8.4.7
-        version: 8.4.7(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))
+        version: 8.4.7(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))
       '@storybook/blocks':
         specifier: 8.4.7
-        version: 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))
+        version: 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))
       '@storybook/react':
         specifier: 8.4.7
-        version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))(typescript@5.8.3)
+        version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.6.0)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))(typescript@5.8.3)
       '@storybook/react-vite':
         specifier: 8.4.7
-        version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.2)(storybook@8.4.7(prettier@3.5.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))
+        version: 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.6.0)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.2)(storybook@8.4.7(prettier@3.6.0))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))
       '@storybook/test':
         specifier: 8.4.7
-        version: 8.4.7(storybook@8.4.7(prettier@3.5.3))
+        version: 8.4.7(storybook@8.4.7(prettier@3.6.0))
       '@storybook/test-runner':
         specifier: ^0.16.0
         version: 0.16.0(@types/node@22.15.30)
@@ -216,12 +216,15 @@ importers:
       postcss-transformselectors:
         specifier: ^2.0.1
         version: 2.0.1
+      prettier:
+        specifier: ^3.6.0
+        version: 3.6.0
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
       storybook:
         specifier: 8.4.7
-        version: 8.4.7(prettier@3.5.3)
+        version: 8.4.7(prettier@3.6.0)
       tailwindcss:
         specifier: ^3.4.11
         version: 3.4.17
@@ -5419,8 +5422,8 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier@3.5.3:
-    resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
+  prettier@3.6.0:
+    resolution: {integrity: sha512-ujSB9uXHJKzM/2GBuE0hBOUgC77CN3Bnpqa+g80bkv3T3A93wL/xlzDATHhnhkzifz/UE2SNOvmbTz5hSkDlHw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -8534,27 +8537,27 @@ snapshots:
     dependencies:
       '@sinonjs/commons': 3.0.1
 
-  '@storybook/addon-actions@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-actions@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/global': 5.0.0
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.3.1
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       uuid: 9.0.1
 
-  '@storybook/addon-backgrounds@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-backgrounds@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-controls@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-controls@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
 
   '@storybook/addon-coverage@1.0.5':
@@ -8570,101 +8573,101 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@storybook/addon-docs@8.4.7(@types/react@18.3.23)(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-docs@8.4.7(@types/react@18.3.23)(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@18.3.23)(react@18.3.1)
-      '@storybook/blocks': 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/csf-plugin': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/react-dom-shim': 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))
+      '@storybook/blocks': 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/csf-plugin': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/react-dom-shim': 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-essentials@8.4.7(@types/react@18.3.23)(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-essentials@8.4.7(@types/react@18.3.23)(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
-      '@storybook/addon-actions': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/addon-backgrounds': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/addon-controls': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/addon-docs': 8.4.7(@types/react@18.3.23)(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/addon-highlight': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/addon-measure': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/addon-outline': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/addon-toolbars': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/addon-viewport': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      storybook: 8.4.7(prettier@3.5.3)
+      '@storybook/addon-actions': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/addon-backgrounds': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/addon-controls': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/addon-docs': 8.4.7(@types/react@18.3.23)(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/addon-highlight': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/addon-measure': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/addon-outline': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/addon-toolbars': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/addon-viewport': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-highlight@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-highlight@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
-  '@storybook/addon-interactions@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-interactions@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/test': 8.4.7(storybook@8.4.7(prettier@3.5.3))
+      '@storybook/instrumenter': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/test': 8.4.7(storybook@8.4.7(prettier@3.6.0))
       polished: 4.3.1
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-links@8.4.7(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-links@8.4.7(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/csf': 0.1.13
       '@storybook/global': 5.0.0
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 18.3.1
 
-  '@storybook/addon-measure@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-measure@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       tiny-invariant: 1.3.3
 
-  '@storybook/addon-onboarding@8.4.7(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-onboarding@8.4.7(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       react-confetti: 6.4.0(react@18.3.1)
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
     transitivePeerDependencies:
       - react
 
-  '@storybook/addon-outline@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-outline@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
 
-  '@storybook/addon-toolbars@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-toolbars@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
-  '@storybook/addon-viewport@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/addon-viewport@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
-  '@storybook/blocks@8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/blocks@8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/csf': 0.1.13
       '@storybook/icons': 1.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
     optionalDependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/builder-vite@8.4.7(storybook@8.4.7(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))':
+  '@storybook/builder-vite@8.4.7(storybook@8.4.7(prettier@3.6.0))(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))':
     dependencies:
-      '@storybook/csf-plugin': 8.4.7(storybook@8.4.7(prettier@3.5.3))
+      '@storybook/csf-plugin': 8.4.7(storybook@8.4.7(prettier@3.6.0))
       browser-assert: 1.2.1
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       ts-dedent: 2.2.0
       vite: 6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0)
 
@@ -8681,9 +8684,9 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
 
-  '@storybook/components@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/components@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
   '@storybook/core-common@7.6.20':
     dependencies:
@@ -8718,7 +8721,7 @@ snapshots:
     dependencies:
       ts-dedent: 2.2.0
 
-  '@storybook/core@8.4.7(prettier@3.5.3)':
+  '@storybook/core@8.4.7(prettier@3.6.0)':
     dependencies:
       '@storybook/csf': 0.1.13
       better-opn: 3.0.2
@@ -8732,15 +8735,15 @@ snapshots:
       util: 0.12.5
       ws: 8.18.2
     optionalDependencies:
-      prettier: 3.5.3
+      prettier: 3.6.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  '@storybook/csf-plugin@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/csf-plugin@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       unplugin: 1.16.1
 
   '@storybook/csf-tools@7.6.20':
@@ -8772,15 +8775,15 @@ snapshots:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  '@storybook/instrumenter@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/instrumenter@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
-  '@storybook/manager-api@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/manager-api@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
   '@storybook/node-logger@7.6.20': {}
 
@@ -8801,29 +8804,29 @@ snapshots:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  '@storybook/preview-api@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/preview-api@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
-  '@storybook/react-dom-shim@8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/react-dom-shim@8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
-  '@storybook/react-vite@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.2)(storybook@8.4.7(prettier@3.5.3))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))':
+  '@storybook/react-vite@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.6.0)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(rollup@2.79.2)(storybook@8.4.7(prettier@3.6.0))(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))':
     dependencies:
       '@joshwooding/vite-plugin-react-docgen-typescript': 0.4.2(typescript@5.8.3)(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))
       '@rollup/pluginutils': 5.1.4(rollup@2.79.2)
-      '@storybook/builder-vite': 8.4.7(storybook@8.4.7(prettier@3.5.3))(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))
-      '@storybook/react': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))(typescript@5.8.3)
+      '@storybook/builder-vite': 8.4.7(storybook@8.4.7(prettier@3.6.0))(vite@6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0))
+      '@storybook/react': 8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.6.0)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))(typescript@5.8.3)
       find-up: 5.0.0
       magic-string: 0.30.17
       react: 18.3.1
       react-docgen: 7.1.1
       react-dom: 18.3.1(react@18.3.1)
       resolve: 1.22.10
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
       tsconfig-paths: 4.2.0
       vite: 6.3.5(@types/node@22.15.30)(jiti@1.21.7)(terser@5.41.0)(yaml@2.8.0)
     transitivePeerDependencies:
@@ -8832,19 +8835,19 @@ snapshots:
       - supports-color
       - typescript
 
-  '@storybook/react@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.5.3)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))(typescript@5.8.3)':
+  '@storybook/react@8.4.7(@storybook/test@8.4.7(storybook@8.4.7(prettier@3.6.0)))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))(typescript@5.8.3)':
     dependencies:
-      '@storybook/components': 8.4.7(storybook@8.4.7(prettier@3.5.3))
+      '@storybook/components': 8.4.7(storybook@8.4.7(prettier@3.6.0))
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/preview-api': 8.4.7(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/react-dom-shim': 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.5.3))
-      '@storybook/theming': 8.4.7(storybook@8.4.7(prettier@3.5.3))
+      '@storybook/manager-api': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/preview-api': 8.4.7(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/react-dom-shim': 8.4.7(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@8.4.7(prettier@3.6.0))
+      '@storybook/theming': 8.4.7(storybook@8.4.7(prettier@3.6.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
     optionalDependencies:
-      '@storybook/test': 8.4.7(storybook@8.4.7(prettier@3.5.3))
+      '@storybook/test': 8.4.7(storybook@8.4.7(prettier@3.6.0))
       typescript: 5.8.3
 
   '@storybook/test-runner@0.16.0(@types/node@22.15.30)':
@@ -8887,21 +8890,21 @@ snapshots:
       - supports-color
       - ts-node
 
-  '@storybook/test@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/test@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
       '@storybook/csf': 0.1.13
       '@storybook/global': 5.0.0
-      '@storybook/instrumenter': 8.4.7(storybook@8.4.7(prettier@3.5.3))
+      '@storybook/instrumenter': 8.4.7(storybook@8.4.7(prettier@3.6.0))
       '@testing-library/dom': 10.4.0
       '@testing-library/jest-dom': 6.5.0
       '@testing-library/user-event': 14.5.2(@testing-library/dom@10.4.0)
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
-  '@storybook/theming@8.4.7(storybook@8.4.7(prettier@3.5.3))':
+  '@storybook/theming@8.4.7(storybook@8.4.7(prettier@3.6.0))':
     dependencies:
-      storybook: 8.4.7(prettier@3.5.3)
+      storybook: 8.4.7(prettier@3.6.0)
 
   '@storybook/types@7.6.20':
     dependencies:
@@ -12943,8 +12946,7 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier@3.5.3:
-    optional: true
+  prettier@3.6.0: {}
 
   pretty-bytes@5.6.0: {}
 
@@ -13667,11 +13669,11 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@8.4.7(prettier@3.5.3):
+  storybook@8.4.7(prettier@3.6.0):
     dependencies:
-      '@storybook/core': 8.4.7(prettier@3.5.3)
+      '@storybook/core': 8.4.7(prettier@3.6.0)
     optionalDependencies:
-      prettier: 3.5.3
+      prettier: 3.6.0
     transitivePeerDependencies:
       - bufferutil
       - supports-color


### PR DESCRIPTION
# What's changed?

This pull request introduces several updates to CI workflows, dependency configurations, and project setup. The most significant changes include the addition of shared CI workflows, updates to the `package.json` file to specify engine requirements, and upgrades to the `prettier` dependency version across the project.

### CI Workflow Enhancements:
* [`.github/workflows/ci-common.yml`](diffhunk://#diff-21a87fb2839073635f0a2cb711e3c0758796c4af8fd4349b552dfd00b6638fcaR1-R36): Added a shared CI workflow (`CI Common`) that performs repository checkout, Node.js setup, dependency installation, formatting checks, linting, building, and testing. This workflow is reusable across other workflows.
* `.github/workflows/ci-alpha.yml` and `.github/workflows/ci.yml`: Introduced new workflows (`CI Alpha` and `CI`) that reuse the shared `ci-common.yml` workflow for pull requests and pushes to specific branches. [[1]](diffhunk://#diff-293063639a32625ceaedc9f5359df6f80fd175c8f5056b9182236a8023d2c4baR1-R11) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR1-R11)

### Dependency Updates:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6-R9): Updated the `engines` field to require Node.js version `>=18` and `pnpm` version `>=8`. Additionally, upgraded `prettier` to version `^3.6.0`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R6-R9) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R113)
* [`pnpm-lock.yaml`](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL116-R137): Reflected the `prettier` version upgrade from `3.5.3` to `3.6.0` across all dependencies and snapshots. [[1]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL116-R137) [[2]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL5422-R5426) [[3]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8537-R8560) [[4]](diffhunk://#diff-32824c984905bb02bc7ffcef96a77addd1f1602cff71a11fbbfdd7f53ee026bbL8890-R8907)

### Project Configuration:
* [`.prettierignore`](diffhunk://#diff-b640b344ee7f3f03d2a443795a5d0708ef50e2e6e34214109ab2aad13ad6ba98R3): Added `.github` directory to the `.prettierignore` file to exclude it from formatting checks.

### Documentation:
* [`.github/pull_request_template.md`](diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR1-R2): Added a placeholder section for summarizing changes in pull requests.